### PR TITLE
fix(semantic): split sentences that exceed chunk_size

### DIFF
--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -395,6 +395,35 @@ class SemanticChunker(BaseChunker):
 
         return groups
 
+    def _split_oversized_sentence(self, sentence: Sentence) -> list[Sentence]:
+        """Split a single sentence that exceeds chunk_size into token-sized pieces.
+
+        A sentence longer than chunk_size can never fit into any group, so grouping
+        alone cannot enforce the limit. We split its text at the token level, the same
+        way TokenChunker does, so no resulting piece exceeds chunk_size.
+
+        Args:
+            sentence: A sentence whose token_count exceeds chunk_size
+
+        Returns:
+            List of sentences, each with token_count <= chunk_size
+
+        """
+        tokens = self.tokenizer.encode(sentence.text)
+        token_groups = [
+            tokens[i : i + self.chunk_size] for i in range(0, len(tokens), self.chunk_size)
+        ]
+        texts = self.tokenizer.decode_batch(token_groups)
+        return [
+            Sentence(
+                text=text,
+                start_index=sentence.start_index,
+                end_index=sentence.start_index + len(text),
+                token_count=len(group),
+            )
+            for text, group in zip(texts, token_groups)
+        ]
+
     def _split_groups(self, groups: list[list[Sentence]]) -> list[list[Sentence]]:
         """Split groups that exceed chunk_size into smaller groups.
 
@@ -418,14 +447,23 @@ class SemanticChunker(BaseChunker):
                 current_token_count = 0
 
                 for sentence in group:
-                    if current_token_count + sentence.token_count <= self.chunk_size:
-                        current_group.append(sentence)
-                        current_token_count += sentence.token_count
-                    else:
-                        if current_group:
-                            final_groups.append(current_group)
-                        current_group = [sentence]
-                        current_token_count = sentence.token_count
+                    # A single sentence larger than chunk_size can't fit in any
+                    # group, so split it into token-sized pieces first.
+                    pieces = (
+                        self._split_oversized_sentence(sentence)
+                        if sentence.token_count > self.chunk_size
+                        else [sentence]
+                    )
+
+                    for piece in pieces:
+                        if current_token_count + piece.token_count <= self.chunk_size:
+                            current_group.append(piece)
+                            current_token_count += piece.token_count
+                        else:
+                            if current_group:
+                                final_groups.append(current_group)
+                            current_group = [piece]
+                            current_token_count = piece.token_count
 
                 if current_group:
                     final_groups.append(current_group)
@@ -465,18 +503,10 @@ class SemanticChunker(BaseChunker):
 
         # Handle edge cases - too few sentences
         if len(sentences) <= self.similarity_window:
-            # If we have any sentences, return them as a single chunk
+            # If we have any sentences, group them together, still enforcing
+            # chunk_size so a few large sentences don't produce an oversized chunk.
             if sentences:
-                text = "".join([s.text for s in sentences])
-                token_count = sum([s.token_count for s in sentences])
-                return [
-                    Chunk(
-                        text=text,
-                        start_index=0,
-                        end_index=len(text),
-                        token_count=token_count,
-                    ),
-                ]
+                return self._create_chunks(self._split_groups([sentences]))
             else:
                 return []
 

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -413,16 +413,23 @@ class SemanticChunker(BaseChunker):
         token_groups = [
             tokens[i : i + self.chunk_size] for i in range(0, len(tokens), self.chunk_size)
         ]
-        texts = self.tokenizer.decode_batch(token_groups)
-        return [
-            Sentence(
-                text=text,
-                start_index=sentence.start_index,
-                end_index=sentence.start_index + len(text),
-                token_count=len(group),
+
+        pieces = []
+        current_start = sentence.start_index
+        for group in token_groups:
+            # Decode one group at a time: decode() is part of the tokenizer
+            # protocol, decode_batch() is not guaranteed for custom tokenizers.
+            text = self.tokenizer.decode(group)
+            pieces.append(
+                Sentence(
+                    text=text,
+                    start_index=current_start,
+                    end_index=current_start + len(text),
+                    token_count=len(group),
+                )
             )
-            for text, group in zip(texts, token_groups)
-        ]
+            current_start += len(text)
+        return pieces
 
     def _split_groups(self, groups: list[list[Sentence]]) -> list[list[Sentence]]:
         """Split groups that exceed chunk_size into smaller groups.

--- a/tests/chunkers/test_semantic_chunker.py
+++ b/tests/chunkers/test_semantic_chunker.py
@@ -101,6 +101,10 @@ def test_semantic_chunker_oversized_single_sentence(embedding_model: BaseEmbeddi
     assert all([chunk.token_count <= chunk_size for chunk in chunks]), (
         "Every chunk must respect chunk_size even when a single sentence is oversized"
     )
+    # Guard against token_count being underreported: re-tokenize the actual text.
+    assert all([chunker.tokenizer.count_tokens(chunk.text) <= chunk_size for chunk in chunks]), (
+        "The tokenized chunk text must also stay within chunk_size"
+    )
 
 
 def test_semantic_chunker_oversized_sentence_below_similarity_window(
@@ -122,6 +126,9 @@ def test_semantic_chunker_oversized_sentence_below_similarity_window(
     assert len(chunks) > 1
     assert all([chunk.token_count <= chunk_size for chunk in chunks]), (
         "The few-sentences path must also split oversized sentences"
+    )
+    assert all([chunker.tokenizer.count_tokens(chunk.text) <= chunk_size for chunk in chunks]), (
+        "The tokenized chunk text must also stay within chunk_size"
     )
 
 

--- a/tests/chunkers/test_semantic_chunker.py
+++ b/tests/chunkers/test_semantic_chunker.py
@@ -75,6 +75,56 @@ def test_semantic_chunker_chunking(embedding_model: BaseEmbeddings, sample_text:
     assert all([chunk.end_index is not None for chunk in chunks])
 
 
+def test_semantic_chunker_oversized_single_sentence(embedding_model: BaseEmbeddings) -> None:
+    """A single sentence longer than chunk_size must still be split to respect the limit.
+
+    Regression test for #222: a sentence with no delimiters that exceeds chunk_size
+    was emitted as one oversized chunk because grouping only splits between sentences.
+    """
+    chunk_size = 100
+    chunker = SemanticChunker(
+        embedding_model=embedding_model,
+        chunk_size=chunk_size,
+        threshold=0.5,
+        min_sentences_per_chunk=1,
+    )
+
+    # One long run of words with no sentence delimiters => a single "sentence"
+    # far larger than chunk_size, surrounded by normal sentences.
+    normal = "This is a normal sentence. Here is another one. And a third here. A fourth now. "
+    oversized = "word " * 800
+    text = normal + oversized + ". " + normal
+
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) > 0
+    assert all([chunk.token_count <= chunk_size for chunk in chunks]), (
+        "Every chunk must respect chunk_size even when a single sentence is oversized"
+    )
+
+
+def test_semantic_chunker_oversized_sentence_below_similarity_window(
+    embedding_model: BaseEmbeddings,
+) -> None:
+    """The few-sentences early-return path must also enforce chunk_size (#222)."""
+    chunk_size = 100
+    chunker = SemanticChunker(
+        embedding_model=embedding_model,
+        chunk_size=chunk_size,
+        threshold=0.5,
+        similarity_window=3,
+    )
+
+    # Fewer sentences than similarity_window, but one is far larger than chunk_size.
+    text = "Short intro. " + ("word " * 600)
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) > 1
+    assert all([chunk.token_count <= chunk_size for chunk in chunks]), (
+        "The few-sentences path must also split oversized sentences"
+    )
+
+
 def test_semantic_chunker_empty_text(embedding_model: BaseEmbeddings) -> None:
     """Test that the SemanticChunker can handle empty text input."""
     chunker = SemanticChunker(


### PR DESCRIPTION
Fixes #222.

## Problem

`SemanticChunker` only splits *between* sentences, never *within* one. When a single sentence tokenizes to more than `chunk_size` (common with delimiter-free content like OpenAPI/JSON specs or very long lines), it was emitted as a single oversized chunk. The issue reporter saw a ~48,811 token chunk with `chunk_size=2048` on the OpenAI OpenAPI YAML.

There were actually two code paths that skipped the size limit:
1. `_split_groups` packs sentences into groups but assumed every individual sentence already fit within `chunk_size`. A sentence larger than `chunk_size` just became its own group unchanged.
2. The few-sentences early-return in `chunk()` (when there are `<= similarity_window` sentences) built a single chunk with no size check at all.

## Fix

- Added `_split_oversized_sentence()`, which splits a too-large sentence into token-sized pieces using `tokenizer.encode` / `decode`, the same way `TokenChunker` already does. `_split_groups` calls it before packing, so no piece ever exceeds `chunk_size`.
- Routed the few-sentences path through `_split_groups` + `_create_chunks` so it enforces the limit too. Output is unchanged when the content already fits.

## Reproduce (before the fix)

```python
from chonkie import SemanticChunker

chunker = SemanticChunker(embedding_model="minishlab/potion-base-8M", chunk_size=200)
text = "A normal sentence here. " + ("word " * 2000) + ". Another normal one."
chunks = chunker.chunk(text)
print(max(c.token_count for c in chunks))   # 2001 before, <= 200 after
```

## Tests

Added two regression tests (oversized sentence in the normal path, and in the few-sentences path). Both fail on `main` and pass with this change. Full `test_semantic_chunker.py` suite is green. `ruff check` and `ruff format --check` are clean on the touched files.

One note: token-level splitting decodes token slices, so on uncased tokenizers the split pieces come back lowercased; this matches `TokenChunker`'s existing behavior and only affects sentences that were too large to keep whole anyway.