### PR TITLE
fix: preserve Unicode token chunk offsets

### DIFF
--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -4,6 +4,7 @@ This module provides a TokenChunker class for splitting text into chunks of a sp
 
 """
 
+from bisect import bisect_right
 from typing import Generator, Sequence, Union
 
 from tqdm import trange
@@ -102,6 +103,70 @@ class TokenChunker(BaseChunker):
 
         return chunks
 
+    def _create_chunks_with_offsets(
+        self,
+        text: str,
+        tokens: Sequence[int],
+        offsets: Sequence[tuple[int, int]],
+    ) -> list[Chunk]:
+        """Create character-safe chunks from tokenizer offsets."""
+        safe_boundaries = [0]
+        for index in range(1, len(tokens)):
+            previous_start, previous_end = offsets[index - 1]
+            current_start, _ = offsets[index]
+            if previous_end > previous_start and previous_end == current_start:
+                safe_boundaries.append(index)
+        safe_boundaries.append(len(tokens))
+
+        chunks = []
+        start = 0
+        while start < len(tokens):
+            requested_end = min(start + self.chunk_size, len(tokens))
+            end = safe_boundaries[bisect_right(safe_boundaries, requested_end) - 1]
+            if end <= start:
+                end = safe_boundaries[bisect_right(safe_boundaries, start)]
+
+            start_index = offsets[start][0]
+            end_index = offsets[end - 1][1]
+            chunks.append(
+                Chunk(
+                    text=text[start_index:end_index],
+                    start_index=start_index,
+                    end_index=end_index,
+                    token_count=end - start,
+                )
+            )
+
+            if end == len(tokens):
+                break
+
+            requested_start = max(0, end - self.chunk_overlap)
+            next_start = safe_boundaries[bisect_right(safe_boundaries, requested_start) - 1]
+            if next_start <= start:
+                next_start = safe_boundaries[bisect_right(safe_boundaries, start)]
+            start = next_start
+
+        return chunks
+
+    def _chunk_tokens(self, text: str, tokens: Sequence[int]) -> list[Chunk]:
+        """Chunk tokens, using source offsets when the tokenizer provides them."""
+        encode_with_offsets = getattr(self.tokenizer, "encode_with_offsets", None)
+        if callable(encode_with_offsets):
+            try:
+                offset_tokens, offsets = encode_with_offsets(text)
+            except (NotImplementedError, ValueError):
+                # Some tokenizer backends do not expose offset mappings. Keep
+                # their existing decode-based behavior in that case.
+                pass
+            else:
+                if list(tokens) == offset_tokens and len(offsets) == len(tokens):
+                    return self._create_chunks_with_offsets(text, tokens, offsets)
+
+        token_groups = list(self._token_group_generator(tokens))
+        token_counts = [len(token_group) for token_group in token_groups]
+        chunk_texts = self.tokenizer.decode_batch(token_groups)
+        return self._create_chunks(chunk_texts, token_groups, token_counts)
+
     def _token_group_generator(self, tokens: Sequence[int]) -> Generator[list[int], None, None]:
         """Generate chunks from a list of tokens."""
         for start in range(0, len(tokens), self.chunk_size - self.chunk_overlap):
@@ -128,15 +193,7 @@ class TokenChunker(BaseChunker):
         # Encode full text
         text_tokens = self.tokenizer.encode(text)
 
-        # Calculate token groups and counts
-        token_groups = list(self._token_group_generator(text_tokens))
-        token_counts = [len(toks) for toks in token_groups]
-
-        # decode the token groups into the chunk texts
-        chunk_texts = self.tokenizer.decode_batch(token_groups)
-
-        # Create the chunks from the token groups and token counts
-        chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
+        chunks = self._chunk_tokens(text, text_tokens)
 
         logger.info(f"Created {len(chunks)} chunks from {len(text_tokens)} tokens")
         return chunks
@@ -147,23 +204,12 @@ class TokenChunker(BaseChunker):
         tokens_list = self.tokenizer.encode_batch(texts)
         result: list = []
 
-        for tokens in tokens_list:
+        for text, tokens in zip(texts, tokens_list):
             if not tokens:
                 result.append([])
                 continue
 
-            # get the token groups
-            token_groups = list(self._token_group_generator(tokens))
-
-            # get the token counts
-            token_counts = [len(token_group) for token_group in token_groups]
-
-            # decode the token groups into the chunk texts
-            chunk_texts = self.tokenizer.decode_batch(token_groups)
-
-            # create the chunks from the token groups and token counts
-            chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
-            result.append(chunks)
+            result.append(self._chunk_tokens(text, tokens))
 
         return result
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -148,20 +148,23 @@ class TokenChunker(BaseChunker):
 
         return chunks
 
-    def _chunk_tokens(self, text: str, tokens: Sequence[int]) -> list[Chunk]:
-        """Chunk tokens, using source offsets when the tokenizer provides them."""
+    def _chunk_with_offsets(self, text: str) -> tuple[list[Chunk], int] | None:
+        """Chunk text with source offsets when the tokenizer provides them."""
         encode_with_offsets = getattr(self.tokenizer, "encode_with_offsets", None)
         if callable(encode_with_offsets):
             try:
                 offset_tokens, offsets = encode_with_offsets(text)
             except (NotImplementedError, ValueError):
-                # Some tokenizer backends do not expose offset mappings. Keep
-                # their existing decode-based behavior in that case.
-                pass
+                return None
             else:
-                if list(tokens) == offset_tokens and len(offsets) == len(tokens):
-                    return self._create_chunks_with_offsets(text, tokens, offsets)
+                if offset_tokens and len(offsets) == len(offset_tokens):
+                    chunks = self._create_chunks_with_offsets(text, offset_tokens, offsets)
+                    return chunks, len(offset_tokens)
 
+        return None
+
+    def _chunk_tokens(self, tokens: Sequence[int]) -> list[Chunk]:
+        """Chunk token IDs using the decode-based fallback."""
         token_groups = list(self._token_group_generator(tokens))
         token_counts = [len(token_group) for token_group in token_groups]
         chunk_texts = self.tokenizer.decode_batch(token_groups)
@@ -190,28 +193,37 @@ class TokenChunker(BaseChunker):
 
         logger.debug(f"Chunking text of length {len(text)} with chunk_size={self.chunk_size}")
 
-        # Encode full text
-        text_tokens = self.tokenizer.encode(text)
+        offset_chunks = self._chunk_with_offsets(text)
+        if offset_chunks is not None:
+            chunks, token_count = offset_chunks
+        else:
+            text_tokens = self.tokenizer.encode(text)
+            chunks = self._chunk_tokens(text_tokens)
+            token_count = len(text_tokens)
 
-        chunks = self._chunk_tokens(text, text_tokens)
-
-        logger.info(f"Created {len(chunks)} chunks from {len(text_tokens)} tokens")
+        logger.info(f"Created {len(chunks)} chunks from {token_count} tokens")
         return chunks
 
     def _process_batch(self, texts: list[str]) -> list[list[Chunk]]:
         """Process a batch of texts."""
-        # encode the texts into tokens in a batch
-        tokens_list = self.tokenizer.encode_batch(texts)
-        result: list = []
+        result: list[list[Chunk] | None] = [None] * len(texts)
+        fallback_indices = []
+        fallback_texts = []
 
-        for text, tokens in zip(texts, tokens_list):
-            if not tokens:
-                result.append([])
-                continue
+        for index, text in enumerate(texts):
+            offset_chunks = self._chunk_with_offsets(text)
+            if offset_chunks is not None:
+                result[index] = offset_chunks[0]
+            else:
+                fallback_indices.append(index)
+                fallback_texts.append(text)
 
-            result.append(self._chunk_tokens(text, tokens))
+        if fallback_texts:
+            tokens_list = self.tokenizer.encode_batch(fallback_texts)
+            for index, tokens in zip(fallback_indices, tokens_list):
+                result[index] = self._chunk_tokens(tokens) if tokens else []
 
-        return result
+        return [chunks if chunks is not None else [] for chunks in result]
 
     def chunk_batch(  # ty: ignore[invalid-method-override]
         self,

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -2,6 +2,7 @@
 
 import inspect
 from abc import ABC, abstractmethod
+from bisect import bisect_right
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol
@@ -23,6 +24,20 @@ _TIKTOKEN_TO_TOKIE_MAPPING = {
     "p50k_base": "Xenova/text-davinci-003",
     "gpt2": "openai-community/gpt2",
 }
+
+
+def _byte_offsets_to_character_offsets(
+    text: str, byte_offsets: Sequence[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Convert UTF-8 byte offsets into offsets into a Python string."""
+    character_boundaries = [0]
+    for character in text:
+        character_boundaries.append(character_boundaries[-1] + len(character.encode("utf-8")))
+
+    def character_offset(byte_offset: int) -> int:
+        return bisect_right(character_boundaries, byte_offset) - 1
+
+    return [(character_offset(start), character_offset(end)) for start, end in byte_offsets]
 
 
 class TokenizerProtocol(Protocol):
@@ -600,6 +615,15 @@ class TiktokenAutoTokenizer(AutoTokenizer):
     if TYPE_CHECKING:
         tokenizer: tiktoken.Encoding
 
+    def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        """Encode text and return character offsets for each token."""
+        token_ids = list(self.encode(text))
+        decoded, starts = self.tokenizer.decode_with_offsets(token_ids)
+        if decoded != text:
+            raise ValueError("Tokenizer did not round-trip the input text.")
+        ends = [*starts[1:], len(text)]
+        return token_ids, list(zip(starts, ends))
+
 
 class TransformersAutoTokenizer(AutoTokenizer):
     """Adapter for HuggingFace `transformers` tokenizers."""
@@ -617,6 +641,11 @@ class TransformersAutoTokenizer(AutoTokenizer):
         """Batch encode texts without special tokens."""
         encoded = self.tokenizer(texts, add_special_tokens=False)
         return encoded["input_ids"]
+
+    def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        """Encode text and return character offsets for each token."""
+        encoded = self.tokenizer(text, add_special_tokens=False, return_offsets_mapping=True)
+        return list(encoded["input_ids"]), [tuple(offset) for offset in encoded["offset_mapping"]]
 
     def decode_batch(self, token_sequences: Sequence[Sequence[int]]) -> Sequence[str]:
         """Batch decode using batch_decode method."""
@@ -644,6 +673,11 @@ class TokenizersAutoTokenizer(AutoTokenizer):
             for encoding in self.tokenizer.encode_batch(texts, add_special_tokens=False)
         ]
 
+    def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        """Encode text and return character offsets for each token."""
+        encoding = self.tokenizer.encode(text, add_special_tokens=False)
+        return encoding.ids, encoding.offsets
+
 
 class TokieAutoTokenizer(AutoTokenizer):
     """Adapter for tokie tokenizers."""
@@ -656,6 +690,11 @@ class TokieAutoTokenizer(AutoTokenizer):
     def encode(self, text: str) -> list[int]:
         """Encode text and extract token IDs."""
         return self.tokenizer.encode(text, add_special_tokens=False).ids
+
+    def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        """Encode text and return character offsets for each token."""
+        encoding = self.tokenizer.encode_with_offsets(text, add_special_tokens=False)
+        return encoding.ids, _byte_offsets_to_character_offsets(text, encoding.offsets)
 
     def decode(self, tokens: Sequence[int]) -> str:
         """Decode token IDs back to text."""

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -676,7 +676,7 @@ class TokenizersAutoTokenizer(AutoTokenizer):
     def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
         """Encode text and return character offsets for each token."""
         encoding = self.tokenizer.encode(text, add_special_tokens=False)
-        return encoding.ids, encoding.offsets
+        return list(encoding.ids), list(encoding.offsets)
 
 
 class TokieAutoTokenizer(AutoTokenizer):
@@ -694,7 +694,7 @@ class TokieAutoTokenizer(AutoTokenizer):
     def encode_with_offsets(self, text: str) -> tuple[list[int], list[tuple[int, int]]]:
         """Encode text and return character offsets for each token."""
         encoding = self.tokenizer.encode_with_offsets(text, add_special_tokens=False)
-        return encoding.ids, _byte_offsets_to_character_offsets(text, encoding.offsets)
+        return list(encoding.ids), _byte_offsets_to_character_offsets(text, encoding.offsets)
 
     def decode(self, tokens: Sequence[int]) -> str:
         """Decode token IDs back to text."""

--- a/tests/chunkers/test_token_chunker.py
+++ b/tests/chunkers/test_token_chunker.py
@@ -8,6 +8,7 @@ import pytest
 import tiktoken
 from tiktoken import Encoding
 from tokenizers import Tokenizer
+from tokie import Tokenizer as TokieTokenizer
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from chonkie import Chunk, TokenChunker
@@ -35,6 +36,15 @@ def tokenizer() -> Tokenizer:
         return Tokenizer.from_pretrained("gpt2")
     except (OSError, ValueError) as e:
         pytest.skip(f"Could not load tokenizers tokenizer: {e}")
+
+
+@pytest.fixture
+def tokie_tokenizer() -> TokieTokenizer:
+    """Fixture that returns a GPT-2 tokenizer from the tokie library."""
+    try:
+        return TokieTokenizer.from_pretrained("openai-community/gpt2")
+    except (OSError, ValueError) as e:
+        pytest.skip(f"Could not load tokie tokenizer: {e}")
 
 
 @pytest.fixture
@@ -276,7 +286,7 @@ def test_token_chunker_indices_complex_md(sample_complex_markdown_text: str) -> 
 
 
 @pytest.mark.parametrize(
-    "tokenizer_fixture", ["tiktokenizer", "tokenizer", "transformers_tokenizer"]
+    "tokenizer_fixture", ["tiktokenizer", "tokenizer", "tokie_tokenizer", "transformers_tokenizer"]
 )
 def test_token_chunker_preserves_unicode_source_offsets(
     request: pytest.FixtureRequest, tokenizer_fixture: str

--- a/tests/chunkers/test_token_chunker.py
+++ b/tests/chunkers/test_token_chunker.py
@@ -275,6 +275,30 @@ def test_token_chunker_indices_complex_md(sample_complex_markdown_text: str) -> 
     verify_chunk_indices(chunks, sample_complex_markdown_text)
 
 
+@pytest.mark.parametrize(
+    "tokenizer_fixture", ["tiktokenizer", "tokenizer", "transformers_tokenizer"]
+)
+def test_token_chunker_preserves_unicode_source_offsets(
+    request: pytest.FixtureRequest, tokenizer_fixture: str
+) -> None:
+    """Test that token boundaries cannot split a multi-byte character."""
+    text = "a🩺 hello world"
+    tokenizer = request.getfixturevalue(tokenizer_fixture)
+    chunker = TokenChunker(tokenizer=tokenizer, chunk_size=2, chunk_overlap=0)
+
+    chunks = chunker.chunk(text)
+
+    assert [chunk.text for chunk in chunks] == ["a", "🩺", " hello world"]
+    assert [chunk.token_count for chunk in chunks] == [1, 3, 2]
+    assert all(chunk.end_index > chunk.start_index for chunk in chunks)
+    verify_chunk_indices(chunks, text)
+
+    for batch_chunks in chunker.chunk_batch([text, text]):
+        assert [chunk.text for chunk in batch_chunks] == ["a", "🩺", " hello world"]
+        assert all(chunk.end_index > chunk.start_index for chunk in batch_chunks)
+        verify_chunk_indices(batch_chunks, text)
+
+
 def test_token_chunker_token_counts(tiktokenizer: Encoding, sample_text: str) -> None:
     """Test that the TokenChunker correctly calculates token counts."""
     chunker = TokenChunker(tokenizer=tiktokenizer, chunk_size=512, chunk_overlap=128)


### PR DESCRIPTION
## Summary
- preserve source-text offsets when byte-level tokenizer boundaries fall inside a multi-byte character
- prevent empty chunks and incorrect indices for Unicode input
- retain the existing decode-based behavior when an adapter does not provide offset mappings

## Root cause
TokenChunker decoded each token group independently and accumulated decoded-string lengths. A group beginning in the middle of a UTF-8 character could decode as empty, which lost text and desynchronized later indices.

## Validation
- pytest tests/chunkers/test_token_chunker.py tests/test_tokenizer.py -q (111 passed)
- Ruff lint, formatting, and diff whitespace checks
- regression coverage for single and batch chunking across tiktoken, tokenizers, and Transformers GPT-2 adapters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token-based chunking for text containing Unicode and multi-byte characters.
  * Preserved accurate source-text boundaries and overlap information when creating chunks.
  * Ensured consistent results between single-text and batch chunking across supported tokenizers.
* **Tests**
  * Added coverage verifying Unicode text preservation and source-range accuracy across multiple tokenizer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->