### PR TITLE
fix(token): validate float chunk_overlap against chunk_size

### DIFF
--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -48,14 +48,19 @@ class TokenChunker(BaseChunker):
         super().__init__(tokenizer)
         if chunk_size <= 0:
             raise ValueError("chunk_size must be positive")
-        if isinstance(chunk_overlap, int) and chunk_overlap >= chunk_size:
-            raise ValueError("chunk_overlap must be less than chunk_size")
 
         # Assign the values if they make sense
         self.chunk_size = chunk_size
         self.chunk_overlap = (
             chunk_overlap if isinstance(chunk_overlap, int) else int(chunk_overlap * chunk_size)
         )
+        # Validate the resolved overlap so a fractional (float) overlap that
+        # maps to >= chunk_size is rejected too. The earlier int-only check let
+        # e.g. chunk_overlap=1.0 through, making the chunk step
+        # (chunk_size - chunk_overlap) zero or negative, which raised an opaque
+        # range() error or silently produced no chunks.
+        if self.chunk_overlap >= chunk_size:
+            raise ValueError("chunk_overlap must be less than chunk_size")
 
         self._use_multiprocessing = False
 

--- a/tests/chunkers/test_token_chunker.py
+++ b/tests/chunkers/test_token_chunker.py
@@ -309,3 +309,23 @@ def test_token_chunker_return_type(tiktokenizer: Encoding, sample_text: str) -> 
     chunks = chunker.chunk(sample_text)
     assert all([type(chunk) is Chunk for chunk in chunks])
     assert all([len(tiktokenizer.encode(chunk.text)) <= 512 for chunk in chunks])
+
+
+@pytest.mark.parametrize("overlap", [1.0, 1.5, 2.0])
+def test_token_chunker_rejects_float_overlap_at_or_above_one(overlap: float) -> None:
+    """A float overlap resolving to >= chunk_size must raise, not drop text.
+
+    A float overlap is treated as a fraction of chunk_size, so 1.0 resolves to
+    chunk_size and 1.5 to more than chunk_size. Before validation covered the
+    float case, these silently produced zero chunks (or crashed with an opaque
+    range() error) because the chunk step became zero or negative.
+    """
+    with pytest.raises(ValueError):
+        TokenChunker(tokenizer="character", chunk_size=100, chunk_overlap=overlap)
+
+
+def test_token_chunker_accepts_valid_fractional_overlap() -> None:
+    """A valid fractional overlap still chunks the text."""
+    chunker = TokenChunker(tokenizer="character", chunk_size=100, chunk_overlap=0.5)
+    chunks = chunker.chunk("a " * 500)
+    assert len(chunks) > 0


### PR DESCRIPTION
### Problem

`TokenChunker` accepts `chunk_overlap` as `Union[int, float]`, where a float is treated as a fraction of `chunk_size`. But the constructor only validated the **int** case:

```python
if isinstance(chunk_overlap, int) and chunk_overlap >= chunk_size:
    raise ValueError("chunk_overlap must be less than chunk_size")
self.chunk_overlap = chunk_overlap if isinstance(chunk_overlap, int) else int(chunk_overlap * chunk_size)
```

So a float `chunk_overlap >= 1.0` resolves to `chunk_overlap >= chunk_size` and slips through. The chunk step `chunk_size - chunk_overlap` then becomes zero or negative:

```python
TokenChunker(tokenizer="character", chunk_size=100, chunk_overlap=1.0).chunk(text)
#   ValueError: range() arg 3 must not be zero

TokenChunker(tokenizer="character", chunk_size=100, chunk_overlap=1.5).chunk(text)
#   returns []  -> the entire input is silently dropped, no error
```

The silent-empty case is the dangerous one: a chunking pipeline loses the document with no signal.

### Fix

Move the overlap validation to *after* the fractional→int conversion and check the resolved value, so both int and float overlaps that reach `chunk_size` are rejected. This also makes `TokenChunker` consistent with `SentenceChunker`, which already validates the resolved overlap.

Valid fractional overlaps (e.g. `0.5`) are unaffected.

### Tests

Adds parametrized tests asserting `chunk_overlap` of `1.0`, `1.5`, and `2.0` raise `ValueError`, plus a check that a valid `0.5` fraction still chunks. The rejection tests fail against the previous validation and pass with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for fractional overlap settings in token-based chunking.
  - Invalid overlaps that match or exceed the configured chunk size now raise a clear error.
  - Valid fractional overlaps continue to generate chunks successfully.

- **Tests**
  - Added coverage for valid and invalid fractional overlap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->